### PR TITLE
feat: add notification bell component

### DIFF
--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,121 @@
+import React, { useState, useEffect } from 'react';
+import { Bell } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { NotificationService } from '@/lib/notificationService';
+import { useAuth } from '@/hooks/useAuth';
+import { NotificationList } from './NotificationList';
+import { Badge } from '@/components/ui/badge';
+import { supabase } from '@/integrations/supabase/client';
+
+export const NotificationBell: React.FC = () => {
+  const { user } = useAuth();
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!user?.id) return;
+
+    const fetchUnreadCount = async () => {
+      const count = await NotificationService.getUnreadCount(user.id);
+      setUnreadCount(count);
+    };
+
+    fetchUnreadCount();
+
+    // Set up real-time subscription for new notifications
+    const subscription = supabase
+      .channel(`notifications:${user.id}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'notifications',
+          filter: `recipient_id=eq.${user.id}`,
+        },
+        (payload) => {
+          console.log('New notification received:', payload);
+          // Increment unread count
+          setUnreadCount(prev => prev + 1);
+          
+          // Show browser notification if permitted
+          if (Notification.permission === 'granted') {
+            const notification = payload.new as any;
+            new Notification(notification.title, {
+              body: notification.message,
+              icon: '/icon-192x192.png', // Add your app icon
+              tag: notification.id,
+            });
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'notifications',
+          filter: `recipient_id=eq.${user.id}`,
+        },
+        () => {
+          // Refresh count when notifications are marked as read
+          fetchUnreadCount();
+        }
+      )
+      .subscribe();
+
+    // Request notification permission
+    if (Notification.permission === 'default') {
+      Notification.requestPermission();
+    }
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [user?.id]);
+
+  const handleNotificationRead = () => {
+    setUnreadCount(prev => Math.max(0, prev - 1));
+  };
+
+  const handleMarkAllRead = async () => {
+    await NotificationService.markAllAsRead();
+    setUnreadCount(0);
+  };
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative"
+          aria-label={`Notifications ${unreadCount > 0 ? `(${unreadCount} unread)` : ''}`}
+        >
+          <Bell className="h-5 w-5" />
+          {unreadCount > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 text-xs"
+            >
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="end">
+        <NotificationList
+          onNotificationRead={handleNotificationRead}
+          onMarkAllRead={handleMarkAllRead}
+          onClose={() => setIsOpen(false)}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add notification bell that subscribes to supabase for real-time updates and browser notifications
- show unread count badge and connect to notification list for read management

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any, etc.)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8f7ab968832dac0eb131215025fc