### PR TITLE
feat: add notification list

### DIFF
--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { formatDistanceToNow } from 'date-fns';
+import { CheckCheck, Bell } from 'lucide-react';
+
+interface NotificationItemProps {
+  notification: any;
+  onMarkAsRead?: (id: string) => void;
+  onClick?: () => void;
+}
+
+export const NotificationItem: React.FC<NotificationItemProps> = ({
+  notification,
+  onMarkAsRead,
+  onClick,
+}) => {
+  const { id, title, message, created_at, read_at, sender } = notification;
+
+  const handleMarkRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onMarkAsRead?.(id);
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex w-full gap-3 p-4 text-left hover:bg-accent cursor-pointer',
+        !read_at && 'bg-muted'
+      )}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+    >
+      <Avatar className="h-8 w-8">
+        {sender?.avatar_url ? (
+          <AvatarImage src={sender.avatar_url} alt={sender.display_name} />
+        ) : (
+          <AvatarFallback>
+            {sender?.display_name?.[0] || <Bell className="h-4 w-4" />}
+          </AvatarFallback>
+        )}
+      </Avatar>
+      <div className="flex-1 space-y-1">
+        <p className="text-sm font-medium leading-none">{title}</p>
+        {message && (
+          <p className="text-sm text-muted-foreground line-clamp-2">{message}</p>
+        )}
+        {created_at && (
+          <p className="text-xs text-muted-foreground">
+            {formatDistanceToNow(new Date(created_at), { addSuffix: true })}
+          </p>
+        )}
+      </div>
+      {!read_at && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 flex-shrink-0"
+          onClick={handleMarkRead}
+          aria-label="Mark as read"
+        >
+          <CheckCheck className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+};
+

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect } from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { NotificationService } from '@/lib/notificationService';
+import { useAuth } from '@/hooks/useAuth';
+import { NotificationItem } from './NotificationItem';
+import { Loader2, CheckCheck, Bell } from 'lucide-react';
+
+interface NotificationListProps {
+  onNotificationRead?: () => void;
+  onMarkAllRead?: () => Promise<void> | void;
+  onClose?: () => void;
+}
+
+export const NotificationList: React.FC<NotificationListProps> = ({
+  onNotificationRead,
+  onMarkAllRead,
+  onClose,
+}) => {
+  const { user } = useAuth();
+  const [notifications, setNotifications] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(true);
+  const [offset, setOffset] = useState(0);
+  const limit = 20;
+
+  useEffect(() => {
+    if (!user?.id) return;
+    fetchNotifications();
+  }, [user?.id]);
+
+  const fetchNotifications = async (loadMore = false) => {
+    if (!user?.id) return;
+
+    setLoading(true);
+    const currentOffset = loadMore ? offset : 0;
+    const data = await NotificationService.getUserNotifications(
+      user.id,
+      limit,
+      currentOffset
+    );
+
+    if (loadMore) {
+      setNotifications(prev => [...prev, ...data]);
+    } else {
+      setNotifications(data);
+    }
+
+    setHasMore(data.length === limit);
+    setOffset(currentOffset + data.length);
+    setLoading(false);
+  };
+
+  const handleMarkAsRead = async (notificationId: string) => {
+    await NotificationService.markAsRead(notificationId);
+    setNotifications(prev =>
+      prev.map(n =>
+        n.id === notificationId ? { ...n, read_at: new Date().toISOString() } : n
+      )
+    );
+    onNotificationRead?.();
+  };
+
+  const handleLoadMore = () => {
+    fetchNotifications(true);
+  };
+
+  const handleMarkAllClick = async () => {
+    await onMarkAllRead?.();
+    setNotifications(prev =>
+      prev.map(n => ({ ...n, read_at: new Date().toISOString() }))
+    );
+  };
+
+  const unreadCount = notifications.filter(n => !n.read_at).length;
+
+  if (loading && notifications.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="border-b p-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          <h3 className="font-semibold">Notifications</h3>
+          {unreadCount > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {unreadCount} new
+            </Badge>
+          )}
+        </div>
+        {unreadCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleMarkAllClick}
+            className="text-xs"
+          >
+            <CheckCheck className="h-4 w-4 mr-1" />
+            Mark all read
+          </Button>
+        )}
+      </div>
+
+      {notifications.length === 0 ? (
+        <div className="p-8 text-center">
+          <Bell className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+          <p className="text-muted-foreground">No notifications yet</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            You'll see alerts, check-ins, and messages here
+          </p>
+        </div>
+      ) : (
+        <>
+          <ScrollArea className="h-[400px]">
+            {notifications.map(notification => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onMarkAsRead={handleMarkAsRead}
+                onClick={() => {
+                  handleMarkAsRead(notification.id);
+                  onClose?.();
+                }}
+              />
+            ))}
+
+            {hasMore && (
+              <div className="p-4 text-center">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleLoadMore}
+                  disabled={loading}
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Loading...
+                    </>
+                  ) : (
+                    'Load more'
+                  )}
+                </Button>
+              </div>
+            )}
+          </ScrollArea>
+
+          <div className="border-t p-3 text-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs text-muted-foreground"
+              onClick={() => {
+                window.location.href = '/settings/notifications';
+                onClose?.();
+              }}
+            >
+              Notification settings
+            </Button>
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+


### PR DESCRIPTION
## Summary
- implement NotificationList component with loading, pagination, mark-read and settings link
- add NotificationItem component to render individual notifications with avatar and read controls

## Testing
- `npm run lint` *(fails: Unexpected any, missing dependencies, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e90a495e0832d9e6ef9c0d01eeb6e