### PR TITLE
feat: add notification bell to header

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { OnboardingFlow } from "@/components/OnboardingFlow";
 import { Settings } from "@/components/Settings";
 import { SMSTest } from "@/components/SMSTest";
 import { CrisisButton } from "@/components/CrisisButton";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -361,6 +362,7 @@ const Index = () => {
             <p className={`${darkMode ? 'text-gray-300' : 'text-gray-700'} text-lg`}>Take a deep breath. We're here for you.</p>
           </div>
           <div className="flex gap-2">
+            <NotificationBell />
             {/* Compact Crisis Button in header */}
             <CrisisButton userId={user?.id || ''} variant="compact" showStatus={false} />
             <button


### PR DESCRIPTION
## Summary
- display notification bell in the main header for quick access

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, missing dependencies, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e9a6cf4d4832db4636675bd002c2d