### PR TITLE
feat: add notification bell to settings headers

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -8,6 +8,7 @@ import { Switch } from "@/components/ui/switch";
 import { SMSIntegration } from "@/components/SMSIntegration";
 import { ArrowLeft, Plus, X, Edit2, TestTube2, Heart, MessageSquare } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 
 interface SupportPerson {
   id: string;
@@ -153,16 +154,19 @@ export const Settings = ({
     <div className="min-h-screen bg-background p-4">
       <div className="max-w-2xl mx-auto space-y-6">
         {/* Header */}
-        <div className="flex items-center space-x-4">
-          <Button
-            onClick={onBack}
-            variant="ghost"
-            size="sm"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back
-          </Button>
-          <h1 className="text-2xl font-bold text-foreground">Settings</h1>
+        <div className="flex items-center justify-between space-x-4">
+          <div className="flex items-center space-x-4">
+            <Button
+              onClick={onBack}
+              variant="ghost"
+              size="sm"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back
+            </Button>
+            <h1 className="text-2xl font-bold text-foreground">Settings</h1>
+          </div>
+          <NotificationBell />
         </div>
 
         {/* My Support Network */}

--- a/src/pages/NotificationSettings.tsx
+++ b/src/pages/NotificationSettings.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Bell } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { NotificationPreferences } from '@/components/notifications/NotificationPreferences';
 import { useAuth } from '@/hooks/useAuth';
+import { NotificationBell } from '@/components/notifications/NotificationBell';
 
 const NotificationSettingsPage = () => {
   const navigate = useNavigate();
@@ -22,19 +23,22 @@ const NotificationSettingsPage = () => {
   return (
     <div className="min-h-screen bg-background p-4">
       <div className="max-w-2xl mx-auto space-y-6">
-        <div className="flex items-center gap-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate('/')}
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back
-          </Button>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Bell className="h-5 w-5" />
-            Notifications
-          </h1>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate('/')}
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back
+            </Button>
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <Bell className="h-5 w-5" />
+              Notifications
+            </h1>
+          </div>
+          <NotificationBell />
         </div>
         <NotificationPreferences />
       </div>


### PR DESCRIPTION
## Summary
- show notifications in Settings and NotificationSettings headers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_688e9c9fe400832d88413ff47a5f86a7