### PR TITLE
feat: add settings layout component

### DIFF
--- a/src/components/settings/SettingsLayout.tsx
+++ b/src/components/settings/SettingsLayout.tsx
@@ -1,0 +1,66 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ProfileSettings } from "./ProfileSettings";
+import { PrivacySettings } from "./PrivacySettings";
+import { NotificationPreferences } from "../notifications/NotificationPreferences";
+import { SupportNetworkSettings } from "./SupportNetworkSettings";
+import { AccountSecurity } from "./AccountSecurity";
+import { User, Shield, Bell, Users, Lock } from "lucide-react";
+
+export function SettingsLayout() {
+  return (
+    <div className="container max-w-4xl mx-auto py-6 space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Settings</h1>
+        <p className="text-muted-foreground mt-2">
+          Manage your account settings and preferences
+        </p>
+      </div>
+
+      <Tabs defaultValue="profile" className="space-y-4">
+        <TabsList className="grid w-full grid-cols-5">
+          <TabsTrigger value="profile" className="flex items-center gap-2">
+            <User className="h-4 w-4" />
+            <span className="hidden sm:inline">Profile</span>
+          </TabsTrigger>
+          <TabsTrigger value="privacy" className="flex items-center gap-2">
+            <Shield className="h-4 w-4" />
+            <span className="hidden sm:inline">Privacy</span>
+          </TabsTrigger>
+          <TabsTrigger value="notifications" className="flex items-center gap-2">
+            <Bell className="h-4 w-4" />
+            <span className="hidden sm:inline">Alerts</span>
+          </TabsTrigger>
+          <TabsTrigger value="network" className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span className="hidden sm:inline">Network</span>
+          </TabsTrigger>
+          <TabsTrigger value="security" className="flex items-center gap-2">
+            <Lock className="h-4 w-4" />
+            <span className="hidden sm:inline">Security</span>
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile">
+          <ProfileSettings />
+        </TabsContent>
+        
+        <TabsContent value="privacy">
+          <PrivacySettings />
+        </TabsContent>
+        
+        <TabsContent value="notifications">
+          <NotificationPreferences />
+        </TabsContent>
+        
+        <TabsContent value="network">
+          <SupportNetworkSettings />
+        </TabsContent>
+        
+        <TabsContent value="security">
+          <AccountSecurity />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add SettingsLayout component with tab navigation for profile, privacy, notifications, network, and security settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eb6a60a98832d947fb34968bda9fc