### PR TITLE
feat: add settings link to navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Auth from "./pages/Auth";
 import SMSTest from "./pages/SMSTest";
 import NotificationSettings from "./pages/NotificationSettings";
 import ProfileSettings from "./pages/ProfileSettings";
+import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -22,6 +23,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/auth" element={<Auth />} />
           <Route path="/sms-test" element={<SMSTest />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route path="/settings/notifications" element={<NotificationSettings />} />
           <Route path="/settings/profile" element={<ProfileSettings />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Heart, Sparkles, Phone, MessageCircle, Headphones, Volume2, Feather, Sun, Moon, Plus, X, Mail, Edit2, Trash2, AlertCircle, CheckCircle, Send, LogOut } from 'lucide-react';
+import { useNavigate, Link } from 'react-router-dom';
+import { Heart, Sparkles, Phone, MessageCircle, Headphones, Volume2, Feather, Sun, Moon, Plus, X, Mail, Edit2, Trash2, AlertCircle, CheckCircle, Send, LogOut, Settings as SettingsIcon } from 'lucide-react';
 import { OnboardingFlow } from "@/components/OnboardingFlow";
 import { Settings } from "@/components/Settings";
 import { SMSTest } from "@/components/SMSTest";
@@ -365,6 +365,13 @@ const Index = () => {
             <NotificationBell />
             {/* Compact Crisis Button in header */}
             <CrisisButton userId={user?.id || ''} variant="compact" showStatus={false} />
+            <Link 
+              to="/settings" 
+              className="flex items-center gap-2 px-3 py-2 rounded-md hover:bg-gray-100"
+            >
+              <SettingsIcon className="h-4 w-4" />
+              Settings
+            </Link>
             <button
               onClick={() => setDarkMode(!darkMode)}
               className={`p-2 rounded-lg ${darkMode ? 'bg-gray-800 text-yellow-400' : 'bg-white text-gray-700'} shadow-md`}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+import { SettingsLayout } from "@/components/settings/SettingsLayout";
+
+const SettingsPage = () => {
+  const navigate = useNavigate();
+  const { user, isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate("/auth");
+    }
+  }, [isAuthenticated, navigate]);
+
+  if (!isAuthenticated || !user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-4">
+      <SettingsLayout />
+    </div>
+  );
+};
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add settings link to main header
- wire up /settings route with new settings page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eba42f0c8832d9bccb19f70cb9c15