### PR TITLE
Add crisis alert page and notification service

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import NotificationSettings from "./pages/NotificationSettings";
 import ProfileSettings from "./pages/ProfileSettings";
 import SettingsPage from "./pages/Settings";
 import NotFound from "./pages/NotFound";
+import CrisisAlert from "./pages/CrisisAlert";
 
 const queryClient = new QueryClient();
 
@@ -26,6 +27,7 @@ const App = () => (
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/settings/notifications" element={<NotificationSettings />} />
           <Route path="/settings/profile" element={<ProfileSettings />} />
+          <Route path="/crisis-alert" element={<CrisisAlert />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/CrisisAlertButton.tsx
+++ b/src/components/CrisisAlertButton.tsx
@@ -33,7 +33,7 @@ export const CrisisAlertButton: React.FC<CrisisAlertButtonProps> = ({
 
   const handleSendAlert = async () => {
     setSending(true);
-    await sendCrisisAlert();
+    await sendCrisisAlert(message);
     setSending(false);
     setShowDialog(false);
     setMessage('');

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { NotificationService } from '@/lib/notificationService';
 
 export function useNotifications() {
   const [notifications] = useState([]);
@@ -8,9 +10,10 @@ export function useNotifications() {
     console.log('Support notification sent');
   };
 
-  const sendCrisisAlert = async () => {
-    // Placeholder for crisis alert functionality
-    console.log('Crisis alert sent');
+  const sendCrisisAlert = async (message: string = 'I need help') => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+    await NotificationService.sendCrisisAlert(user.id, message);
   };
 
   return {

--- a/src/lib/notificationService.ts
+++ b/src/lib/notificationService.ts
@@ -1,0 +1,7 @@
+import { sendCrisisAlert } from "./sms";
+
+export class NotificationService {
+  static async sendCrisisAlert(userId: string, message: string) {
+    return await sendCrisisAlert(userId, message);
+  }
+}

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -84,7 +84,7 @@ export async function sendSMS(phoneNumber: string, message: string, userId?: str
 }
 
 // Crisis alert function using your existing database structure
-export async function sendCrisisAlert(userId: string) {
+export async function sendCrisisAlert(userId: string, customMessage?: string) {
   try {
     console.log(`🚨 Crisis alert triggered for user: ${userId}`);
 
@@ -105,7 +105,8 @@ export async function sendCrisisAlert(userId: string) {
       throw new Error('No emergency contacts configured');
     }
 
-    const message = `🚨 CRISIS ALERT: Your contact needs immediate support. Please reach out to them right away. If this is an emergency, call 911. Sent from Recovery App.`;
+    const message = customMessage ||
+      `🚨 CRISIS ALERT: Your contact needs immediate support. Please reach out to them right away. If this is an emergency, call 911. Sent from Recovery App.`;
 
     // Send SMS to all emergency contacts
     const smsPromises = contacts.map(contact => 

--- a/src/pages/CrisisAlert.tsx
+++ b/src/pages/CrisisAlert.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { AlertTriangle, ArrowLeft, Send } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { NotificationService } from "@/lib/notificationService";
+
+export function CrisisAlert() {
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  async function sendCrisisAlert() {
+    if (!message.trim()) {
+      toast({
+        title: "Error",
+        description: "Please enter a message",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setSending(true);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Not authenticated");
+
+      // Send crisis alert using the notification service
+      await NotificationService.sendCrisisAlert(user.id, message);
+
+      toast({
+        title: "Crisis Alert Sent",
+        description: "Your support network has been notified",
+      });
+
+      // Navigate back after short delay
+      setTimeout(() => navigate("/"), 1500);
+    } catch (error) {
+      console.error("Error sending crisis alert:", error);
+      toast({
+        title: "Error",
+        description: "Failed to send crisis alert",
+        variant: "destructive",
+      });
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="container max-w-2xl mx-auto py-6 space-y-6">
+      <Button variant="ghost" onClick={() => navigate("/")} className="mb-4">
+        <ArrowLeft className="h-4 w-4 mr-2" />
+        Back
+      </Button>
+
+      <Card className="border-red-200">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-red-700">
+            <AlertTriangle className="h-6 w-6" />
+            Send Crisis Alert
+          </CardTitle>
+          <CardDescription>
+            This will immediately notify your entire support network
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p className="text-sm text-red-700">
+              <strong>Important:</strong> Crisis alerts are for urgent situations only.
+              Your support network will receive immediate notifications via app and SMS.
+            </p>
+          </div>
+
+          <Textarea
+            placeholder="What's happening? How can your support network help?"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={4}
+            className="resize-none"
+          />
+
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              onClick={() => navigate("/")}
+              disabled={sending}
+              className="flex-1"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={sendCrisisAlert}
+              disabled={sending || !message.trim()}
+              className="flex-1 bg-red-600 hover:bg-red-700"
+            >
+              {sending ? (
+                "Sending..."
+              ) : (
+                <>
+                  <Send className="h-4 w-4 mr-2" />
+                  Send Alert
+                </>
+              )}
+            </Button>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-muted-foreground mb-2">Need immediate help?</p>
+            <div className="space-y-2">
+              <Button
+                variant="link"
+                onClick={() => (window.location.href = "tel:988")}
+                className="text-blue-600"
+              >
+                Call 988 (Suicide & Crisis Lifeline)
+              </Button>
+              <Button
+                variant="link"
+                onClick={() => (window.location.href = "tel:911")}
+                className="text-blue-600 block"
+              >
+                Call 911 (Emergency)
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default CrisisAlert;


### PR DESCRIPTION
## Summary
- implement `NotificationService` and extend SMS crisis alert to accept custom messages
- wire crisis alert button and notifications hook to the service
- add dedicated Crisis Alert page and route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f707aefe8832dab77a6f9067c4eaa