### PR TITLE
feat: expose supabase client on window

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,8 @@ import App from './App.tsx'
 import './index.css'
 import { supabase } from "@/integrations/supabase/client";
 
-// Add this line to make supabase available in console for testing
-if (process.env.NODE_ENV === 'development') {
+// Make supabase available in browser console for testing
+if (typeof window !== 'undefined') {
   (window as any).supabase = supabase;
 }
 


### PR DESCRIPTION
## Summary
- expose Supabase client on `window` for console access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f85961314832d8bbea94146382882