### PR TITLE
feat: add test notifications component to home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { Heart, Sparkles, Phone, MessageSquare, Headphones, Volume2, Feather, Su
 import { OnboardingFlow } from "@/components/OnboardingFlow";
 import { Settings } from "@/components/Settings";
 import { SMSTest } from "@/components/SMSTest";
+import { TestNotifications } from "@/components/TestNotifications";
 import { CrisisButton } from "@/components/CrisisButton";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { Button } from "@/components/ui/button";
@@ -627,8 +628,9 @@ const Index = () => {
 
         {/* SMS Test Section - for development/testing */}
         {user && (
-          <div className="mt-8">
+          <div className="mt-8 space-y-8">
             <SMSTest />
+            <TestNotifications />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- enable notification testing in the home page by importing and rendering `TestNotifications`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f8b382838832da961970925687887